### PR TITLE
Move job-lifecycle responsibility into Matcher

### DIFF
--- a/backend/main/management/commands/run_matcher_job.py
+++ b/backend/main/management/commands/run_matcher_job.py
@@ -1,5 +1,3 @@
-import argparse
-
 from django.core.management.base import BaseCommand
 
 from main.services.matching.matcher import Matcher
@@ -8,10 +6,5 @@ from main.services.matching.matcher import Matcher
 class Command(BaseCommand):
     help = "Processes a single Matching Job"
 
-    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
-        parser.add_argument("job_id", type=int, help="ID of the Job to process")
-
     def handle(self, *args: str, **options: str) -> None:
-        job_id = int(options["job_id"])
-
-        Matcher().process_job(job_id)
+        Matcher().process_next_job()

--- a/backend/main/services/matching/job_runner.py
+++ b/backend/main/services/matching/job_runner.py
@@ -2,8 +2,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Optional
 
-from main.models import Job
-
 
 @dataclass
 class JobResult:
@@ -13,5 +11,5 @@ class JobResult:
 
 class JobRunner(ABC):
     @abstractmethod
-    def run_job(self, job: Job) -> JobResult:
+    def run_job(self) -> JobResult:
         pass

--- a/backend/main/services/matching/matcher.py
+++ b/backend/main/services/matching/matcher.py
@@ -1,6 +1,7 @@
 import gc
 import logging
 from typing import (
+    Optional,
     TypedDict,
     cast,
 )
@@ -10,7 +11,8 @@ import pandas as pd
 from django.db import connection, transaction
 from django.db.backends.utils import CursorWrapper
 from django.db.models import Field
-from django.forms.models import model_to_dict
+from django.forms import model_to_dict
+from django.utils import timezone
 from psycopg import sql
 from splink import DuckDBAPI, Linker  # type: ignore[import-untyped]
 
@@ -18,6 +20,7 @@ from main.models import (
     TIMESTAMP_FORMAT,
     DbLockId,
     Job,
+    JobStatus,
     MatchEvent,
     MatchEventType,
     MatchGroup,
@@ -507,6 +510,8 @@ class Matcher:
         num_records_loaded = self.load_person_records_with_persons(
             cursor, job, match_event, person_id_temp_table
         )
+
+        # TODO: Should we compare num_records_left with num_records_loaded?
 
         # Load PersonActions that represent the assignment of PersonRecords to Persons
         self.create_new_id_person_actions(cursor, job, match_event)
@@ -1709,95 +1714,180 @@ class Matcher:
     # Processing job
     #
 
-    def process_job(self, job_id: int) -> None:
-        with transaction.atomic(durable=True):
-            with connection.cursor() as cursor:
-                # Obtain (wait for) lock to prevent multiple Matchers from processing jobs at the same time.
-                # Jobs should be processed sequentially.
-                lock_acquired = obtain_advisory_lock(cursor, DbLockId.matching_job)
-                assert lock_acquired
+    def process_job(self, cursor: CursorWrapper, job: Job) -> None:
+        # Create new Persons for PersonRecordStaging rows with job ID.
+        # Then join those new Persons with the PersonRecordStaging rows to link
+        # the FK and insert into the PersonRecord table.
+        num_records_loaded = self.load_person_records(cursor, job)
 
-                try:
-                    job = Job.objects.get(id=job_id)
-                    self.logger.info("Processing job: %s", model_to_dict(job))
-                except Job.DoesNotExist:
-                    self.logger.exception("Job does not exist")
-                    # We want to throw, since the Matcher is run in it's own process and we want to return
-                    # a non-zero exit code if the Job fails.
-                    raise
+        if num_records_loaded == 0:
+            self.logger.info("Job finished")
+            return
 
-                # Create new Persons for PersonRecordStaging rows with job ID.
-                # Then join those new Persons with the PersonRecordStaging rows to link
-                # the FK and insert into the PersonRecord table.
-                num_records_loaded = self.load_person_records(cursor, job)
+        # Extract PersonRecord table to Pandas DF
+        person_record_df = self.extract_person_records(cursor)
 
-                if num_records_loaded == 0:
-                    self.logger.info("Job finished")
-                    return
+        # Run Splink prediction
+        new_result_df = self.run_splink_prediction(job, person_record_df)
 
-                # Extract PersonRecord table to Pandas DF
-                person_record_df = self.extract_person_records(cursor)
+        if new_result_df.empty:
+            self.logger.info("No new Splink prediction results")
+            self.logger.info("Job finished")
+            return
 
-                # Run Splink prediction
-                new_result_df = self.run_splink_prediction(job, person_record_df)
+        lock_acquired = obtain_advisory_lock(cursor, DbLockId.match_update)
+        assert lock_acquired
 
-                if new_result_df.empty:
-                    self.logger.info("No new Splink prediction results")
-                    self.logger.info("Job finished")
-                    return
+        # Lock and retrieve current SplinkResults
+        current_result_df = self.extract_current_results_with_lock(cursor, job)
 
-                lock_acquired = obtain_advisory_lock(cursor, DbLockId.match_update)
-                assert lock_acquired
+        # Concat current SplinkResults with new SplinkResults
+        splink_result_df = self.get_all_results(current_result_df, new_result_df)
 
-                # Lock and retrieve current SplinkResults
-                current_result_df = self.extract_current_results_with_lock(cursor, job)
+        # Lock and retrieve PersonRecord/Person rows related to current SplinkResults
+        person_crosswalk_df = self.extract_person_crosswalk_with_lock(
+            cursor, job, splink_result_df
+        )
 
-                # Concat current SplinkResults with new SplinkResults
-                splink_result_df = self.get_all_results(
-                    current_result_df, new_result_df
+        # Select a subset of columns for use in matching below
+        result_partial_df = splink_result_df[
+            [
+                "row_number",
+                "match_probability",
+                "person_record_l_id",
+                "person_record_r_id",
+            ]
+        ]
+
+        # Generate ResultGroupPartialDict objects, MatchGroupPartialDict objects and auto-match
+        # actions
+        match_graph = MatchGraph(result_partial_df, person_crosswalk_df)
+        match_analysis = match_graph.analyze_graph(job.config.auto_match_threshold)
+
+        # Create Match Event
+        match_event = self.create_match_event(cursor, job, MatchEventType.auto_matches)
+
+        # Load SplinkResult, MatchGroup an MatchGroupAction rows
+        self.load_results_groups_and_actions(
+            cursor,
+            job,
+            match_event,
+            splink_result_df,
+            match_analysis["results"],
+            match_analysis["match_groups"],
+        )
+
+        # Update Person membership based on auto-matches and load PersonActions related to
+        # 'auto-matches'
+        self.update_persons_and_load_actions(
+            cursor, job, match_event, match_analysis["person_actions"]
+        )
+
+        self.logger.info("Job finished")
+
+    def update_job_success(self, job: Job) -> None:
+        self.logger.info(f"Job {job.id} succeeded")
+        updated_count = Job.objects.filter(id=job.id).update(
+            status=JobStatus.succeeded, updated=timezone.now(), reason=None
+        )
+        if updated_count != 1:
+            raise Exception(
+                f"Failed to update job status for job {job.id}."
+                f" Expected to update 1 row, but updated {updated_count}"
+            )
+
+    def update_job_failure(self, job: Job, reason: str) -> None:
+        self.logger.error(f"Job {job.id} failed: {reason}")
+        updated_count = Job.objects.filter(id=job.id).update(
+            status=JobStatus.failed,
+            updated=timezone.now(),
+            reason=f"Error: {reason}",
+        )
+        if updated_count != 1:
+            raise Exception(
+                f"Failed to update job status for job {job.id}."
+                f" Expected to update 1 row, but updated {updated_count}"
+            )
+
+    def delete_staging_records(self, job: Job) -> None:
+        self.logger.info(f"Deleting staging records with job ID {job.id}")
+        deleted_count, _ = PersonRecordStaging.objects.filter(job_id=job.id).delete()
+        self.logger.info(
+            f"Deleted {deleted_count} staging records with job ID {job.id}"
+        )
+
+    def cleanup_failed_job(self, job: Optional[Job], e: Exception) -> None:
+        if job:
+            with transaction.atomic(durable=True):
+                refreshed_job = (
+                    Job.objects.select_for_update().filter(id=job.id).first()
                 )
 
-                # Lock and retrieve PersonRecord/Person rows related to current SplinkResults
-                person_crosswalk_df = self.extract_person_crosswalk_with_lock(
-                    cursor, job, splink_result_df
-                )
+                if refreshed_job:
+                    # The main transaction ended, so there is a potential that the Job was
+                    # marked as succeeded or failed after the main transaction ended and before
+                    # this error handling transaction started. We don't want to overwrite the
+                    # Job status in that case.
+                    if refreshed_job.status == JobStatus.new:
+                        self.update_job_failure(refreshed_job, str(e))
+                        self.delete_staging_records(refreshed_job)
+                    else:
+                        self.logger.error(
+                            "Failed to update Job failure status and cleanup staging records."
+                            f" Job {refreshed_job.id} status is {refreshed_job.status}, expected {JobStatus.new.value}."
+                        )
+                        raise Exception(
+                            "Failed to update Job failure status and cleanup staging records."
+                            f" Job {refreshed_job.id} status is {refreshed_job.status}, expected {JobStatus.new.value}."
+                        ) from e
+                else:
+                    self.logger.error(
+                        "Failed to update Job failure status and cleanup staging records."
+                        f" Job {job.id} does not exist."
+                    )
+                    raise Exception(
+                        "Failed to update Job failure status and cleanup staging records."
+                        f" Job {job.id} does not exist."
+                    ) from e
+        else:
+            self.logger.error(
+                "No current Job, skipping Job failure status update and staging records cleanup"
+            )
+            raise Exception(
+                "No current Job, skipping Job failure status update and staging records cleanup"
+            ) from e
 
-                # Select a subset of columns for use in matching below
-                result_partial_df = splink_result_df[
-                    [
-                        "row_number",
-                        "match_probability",
-                        "person_record_l_id",
-                        "person_record_r_id",
-                    ]
-                ]
+    def process_next_job(self) -> None:
+        job: Optional[Job] = None
 
-                # Generate ResultGroupPartialDict objects, MatchGroupPartialDict objects and auto-match
-                # actions
-                match_graph = MatchGraph(result_partial_df, person_crosswalk_df)
-                match_analysis = match_graph.analyze_graph(
-                    job.config.auto_match_threshold
-                )
+        try:
+            with transaction.atomic(durable=True):
+                with connection.cursor() as cursor:
+                    # Obtain (wait for) lock to prevent multiple Matchers from processing jobs at the
+                    # same time. Jobs should be processed sequentially.
+                    lock_acquired = obtain_advisory_lock(cursor, DbLockId.matching_job)
+                    assert lock_acquired
 
-                # Create Match Event
-                match_event = self.create_match_event(
-                    cursor, job, MatchEventType.auto_matches
-                )
+                    self.logger.info("Checking for new jobs")
 
-                # Load SplinkResult, MatchGroup an MatchGroupAction rows
-                self.load_results_groups_and_actions(
-                    cursor,
-                    job,
-                    match_event,
-                    splink_result_df,
-                    match_analysis["results"],
-                    match_analysis["match_groups"],
-                )
+                    job = (
+                        Job.objects.select_for_update()
+                        .filter(status=JobStatus.new)
+                        .order_by("id")
+                        .first()
+                    )
 
-                # Update Person membership based on auto-matches and load PersonActions related to
-                # 'auto-matches'
-                self.update_persons_and_load_actions(
-                    cursor, job, match_event, match_analysis["person_actions"]
-                )
+                    if not job:
+                        self.logger.info("No new jobs found")
+                        return
 
-                self.logger.info("Job finished")
+                    self.logger.info("Found job: %s", model_to_dict(job))
+
+                    self.process_job(cursor, job)
+                    self.update_job_success(job)
+                    self.delete_staging_records(job)
+        except Exception as e:
+            self.logger.exception(
+                f"Unexpected error while processing next Job {job.id if job else None}: {e}"
+            )
+            self.cleanup_failed_job(job, e)

--- a/backend/main/services/matching/matching_service.py
+++ b/backend/main/services/matching/matching_service.py
@@ -7,14 +7,11 @@ from types import FrameType
 from typing import Optional
 
 from django.db import connection, transaction
-from django.forms.models import model_to_dict
-from django.utils import timezone
 
 from main.models import (
     DbLockId,
     Job,
     JobStatus,
-    PersonRecordStaging,
 )
 from main.services.matching.job_runner import JobRunner
 from main.services.matching.process_job_runner import ProcessJobRunner
@@ -24,18 +21,23 @@ from main.util.sql import obtain_advisory_lock
 class MatchingService:
     logger: logging.Logger
     job_runner: JobRunner
-    cancel: bool
+    cancel: threading.Event
 
     def __init__(self) -> None:
         self.logger = logging.getLogger(__name__)
         self.job_runner = ProcessJobRunner()
-        self.cancel = False
+        self.cancel = threading.Event()
 
         if threading.current_thread() is threading.main_thread():
             signal.signal(signal.SIGINT, self.handle_sigint)
+            signal.signal(signal.SIGTERM, self.handle_sigterm)
+
+    def handle_sigterm(self, _: int, __: Optional[FrameType]) -> None:
+        self.logger.info("SIGTERM received, stopping gracefully")
+        self.stop()
 
     def handle_sigint(self, _: int, __: Optional[FrameType]) -> None:
-        if not self.cancel:
+        if not self.cancel.is_set():
             self.logger.info(
                 "Ctrl+C received, stopping gracefully. Type Ctrl+C again to stop immediately"
             )
@@ -44,79 +46,37 @@ class MatchingService:
             self.logger.info("Second Ctrl+C received, stopping immediately")
             sys.exit(1)
 
-    def get_next_job(self) -> Optional[Job]:
-        return (
-            # no_key - doesn't lock on the primary key column (if it did, then txs in the child
-            # process would wait trying to reference it as a foreign key)
-            Job.objects.select_for_update(no_key=True)
-            .filter(status=JobStatus.new)
-            .order_by("id")
-            .first()
-        )
+    def get_available_jobs_count(self) -> int:
+        return Job.objects.filter(status=JobStatus.new).count()
 
     def run_next_job(self) -> None:
         with transaction.atomic(durable=True):
-            self.logger.info("Retrieving next job")
-
             # Obtain (wait for) lock to prevent multiple MatchingServices from running jobs at the same time.
             # Jobs should be run sequentially.
             with connection.cursor() as cursor:
                 lock_acquired = obtain_advisory_lock(cursor, DbLockId.matching_service)
                 assert lock_acquired
 
-            # Waits on next job
-            job = self.get_next_job()
+            self.logger.info("Checking if there are any new jobs available")
 
-            if not job:
+            jobs_available = self.get_available_jobs_count()
+
+            if jobs_available == 0:
                 self.logger.info("No new jobs found")
-                time.sleep(20)
+                time.sleep(10)
                 return
 
-            self.logger.info("Found job: %s", model_to_dict(job))
+            self.logger.info(f"Found {jobs_available} new job(s). Running Matcher")
 
             start_time = time.perf_counter()
 
-            try:
-                job_result = self.job_runner.run_job(job)
+            # If run_job throws, we allow it to bubble up and retry in the main start loop
+            job_result = self.job_runner.run_job()
 
-                # NOTE: The MatchingService is vulnerable to the dual-write problem. For example,
-                # the Job may succeed (or fail) and we fail to record the status of the job at
-                # this point (due to network issue or sigkill). Matcher is idempotent (if you re-run
-                # Matcher with the same input records, it will return early if those records already
-                # exist in the DB) so it's not an issue as long as the Matcher code is correct. But
-                # we can resolve the problem entirely.
-                if job_result.return_code == 0:
-                    self.logger.info(f"Job {job.id} succeeded")
-                    Job.objects.filter(id=job.id).update(
-                        status=JobStatus.succeeded, updated=timezone.now(), reason=None
-                    )
-                else:
-                    self.logger.error(
-                        f"Job {job.id} failed: {job_result.error_message}"
-                    )
-                    Job.objects.filter(id=job.id).update(
-                        status=JobStatus.failed,
-                        updated=timezone.now(),
-                        reason=f"Job failed with exit code {job_result.return_code}: {job_result.error_message}",
-                    )
-
-            # FIXME: We don't want to catch errors due to the DB calls above
-            # FIXME: This won't commit if the above errors are DatabaseError
-            except Exception as e:
-                self.logger.exception(f"Failed to run job {job.id}: {str(e)}")
-                Job.objects.filter(id=job.id).update(
-                    status=JobStatus.failed,
-                    updated=timezone.now(),
-                    reason=f"Failed to run job: {str(e)}",
+            if job_result.return_code != 0:
+                self.logger.error(
+                    f"Unexpected job runner failure: {job_result.error_message}"
                 )
-
-            self.logger.info(f"Deleting staging records with job ID {job.id}")
-            deleted_count, _ = PersonRecordStaging.objects.filter(
-                job_id=job.id
-            ).delete()
-            self.logger.info(
-                f"Deleted {deleted_count} staging records with job ID {job.id}"
-            )
 
             end_time = time.perf_counter()
             elapsed_time = end_time - start_time
@@ -128,19 +88,16 @@ class MatchingService:
 
         try:
             while True:
-                if self.cancel:
+                if self.cancel.is_set():
                     break
 
                 try:
                     self.run_next_job()
                 except Exception:
-                    self.logger.error(
-                        "Unexpected error processing match job", exc_info=True
-                    )
-                    raise
+                    self.logger.exception("Unexpected job runner failure")
         finally:
             self.logger.info("MatchingService stopped")
 
     def stop(self) -> None:
         self.logger.info("Stopping MatchingService gracefully")
-        self.cancel = True
+        self.cancel.set()

--- a/backend/main/services/matching/process_job_runner.py
+++ b/backend/main/services/matching/process_job_runner.py
@@ -2,8 +2,8 @@ import logging
 import selectors
 import subprocess
 import sys
+from typing import Optional
 
-from main.models import Job
 from main.services.matching.job_runner import JobResult, JobRunner
 
 
@@ -13,58 +13,73 @@ class ProcessJobRunner(JobRunner):
     def __init__(self) -> None:
         self.logger = logging.getLogger(__name__)
 
-    def run_job(self, job: Job) -> JobResult:
-        process = subprocess.Popen(
-            ["python", "manage.py", "run_matcher_job", f"{job.id}"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            close_fds=True,
-            text=True,
-            bufsize=1,
-        )
-        sel = selectors.DefaultSelector()
-        stderr_lines: list[str] = []
+    def run_job(self) -> JobResult:
+        process: Optional[subprocess.Popen[str]] = None
 
-        if process.stderr is not None and process.stdout is not None:
-            sel.register(process.stdout, selectors.EVENT_READ)
-            sel.register(process.stderr, selectors.EVENT_READ)
+        try:
+            process = subprocess.Popen(
+                ["python", "manage.py", "run_matcher_job"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                close_fds=True,
+                text=True,
+                bufsize=1,
+            )
+            try:
+                sel = selectors.DefaultSelector()
+                stderr_lines: list[str] = []
 
-            # While there are still streams registered
-            while sel.get_map():
-                # Wait for new data on a stream
-                for key, _ in sel.select():
-                    file_obj = key.fileobj
+                if process.stderr is not None and process.stdout is not None:
+                    sel.register(process.stdout, selectors.EVENT_READ)
+                    sel.register(process.stderr, selectors.EVENT_READ)
 
-                    if hasattr(file_obj, "readline"):
-                        line = file_obj.readline()
+                    # While there are still streams registered
+                    while sel.get_map():
+                        # Wait for new data on a stream
+                        for key, _ in sel.select():
+                            file_obj = key.fileobj
 
-                        # Received EOF from stream (it's closed or broken), so unregister it
-                        if not line:
-                            sel.unregister(file_obj)
-                            continue
+                            if hasattr(file_obj, "readline"):
+                                line = file_obj.readline()
 
-                        if file_obj is process.stdout:
-                            print(line.rstrip())
-                        else:
-                            print(line.rstrip(), file=sys.stderr)
-                            stderr_lines.append(line)
+                                # Received EOF from stream (it's closed or broken), so unregister it
+                                if not line:
+                                    sel.unregister(file_obj)
+                                    continue
 
-            sel.close()
-            if process.stdout is not None:
-                process.stdout.close()
-            if process.stderr is not None:
-                process.stderr.close()
+                                if file_obj is process.stdout:
+                                    print(line.rstrip())
+                                else:
+                                    print(line.rstrip(), file=sys.stderr)
+                                    stderr_lines.append(line)
+            finally:
+                sel.close()
+                if process.stdout is not None:
+                    process.stdout.close()
+                if process.stderr is not None:
+                    process.stderr.close()
 
-        # Let's make sure the process is finished before checking the return code
-        process.wait()
+            # Let's make sure the process is finished before checking the return code
+            process.wait()
 
-        self.logger.info(f"Job process exited with code {process.returncode}")
+            self.logger.info(f"Job process exited with code {process.returncode}")
 
-        if process.returncode == 0:
-            error_message = None
-        else:
-            error_message = (
-                "".join(stderr_lines) if stderr_lines else "Unknown error occurred"
+            if process.returncode == 0:
+                error_message = None
+            else:
+                error_message = (
+                    "".join(stderr_lines) if stderr_lines else "Unknown error occurred"
+                )
+
+            return JobResult(
+                return_code=process.returncode, error_message=error_message
             )
 
-        return JobResult(return_code=process.returncode, error_message=error_message)
+        finally:
+            if process:
+                # If the process is still running, kill it
+                if process.poll() is None:
+                    self.logger.warning("Killing Job process")
+                    process.kill()
+
+                process.wait()

--- a/backend/main/tests/services/matching/test_matcher.py
+++ b/backend/main/tests/services/matching/test_matcher.py
@@ -2568,7 +2568,9 @@ class MatcherConcurrencyTestCase(TransactionTestCase):
         self.job1.refresh_from_db()
         self.assertEqual(self.job1.status, JobStatus.failed)
         self.assertEqual(self.job1.reason, "Error: Test error")
-        self.assertLess(self.job1.updated, datetime.fromtimestamp(t1_exit, tz=tz.utc))
+        self.assertLess(
+            self.job1.updated, datetime.fromtimestamp(cast(float, t1_exit), tz=tz.utc)
+        )
 
         self.job2.refresh_from_db()
         self.assertEqual(self.job2.status, JobStatus.new)

--- a/backend/main/tests/services/matching/test_matching_service.py
+++ b/backend/main/tests/services/matching/test_matching_service.py
@@ -42,45 +42,73 @@ class MatchingServiceTestCase(TestCase):
 
     @patch("main.services.matching.process_job_runner.ProcessJobRunner.run_job")
     def test_run_next_job_failure(self, mock_run_job: MagicMock) -> None:
-        """Method run_next_job should update the Job in the DB if Job runner fails to run the Job."""
+        """Method run_next_job should log error if Job runner fails to run the Job."""
         mock_run_job.return_value = JobResult(1, "Out of memory\n")
+        self.matching_service.logger = MagicMock()
 
         self.matching_service.run_next_job()
 
         # Refresh the job from the database to get updated status
         self.job.refresh_from_db()
 
-        # Assert that the job status is failed and the reason is saved
-        self.assertEqual(self.job.status, JobStatus.failed)
-        self.assertIn("Out of memory", str(self.job.reason))
+        # Assert that the job status is still new
+        self.assertEqual(self.job.status, JobStatus.new)
+        self.assertIsNone(self.job.reason)
+
+        # Failure is logged
+        self.matching_service.logger.error.assert_called_with(
+            "Unexpected job runner failure: Out of memory\n"
+        )
+        self.assertTrue(
+            any(
+                call.args[0].startswith("Processed job")
+                for call in self.matching_service.logger.info.call_args_list
+            )
+        )
 
     @patch("main.services.matching.process_job_runner.ProcessJobRunner.run_job")
     def test_run_next_job_failure_exc(self, mock_run_job: MagicMock) -> None:
-        """Method run_next_job should update the Job in the DB if Job runner throws an exception."""
+        """Method run_next_job should throw if Job runner throws an exception."""
         mock_run_job.side_effect = ValueError("Out of memory exception")
 
-        self.matching_service.run_next_job()
+        with self.assertRaisesMessage(ValueError, "Out of memory exception"):
+            self.matching_service.run_next_job()
 
         # Refresh the job from the database to get updated status
         self.job.refresh_from_db()
 
-        # Assert that the job status is failed and the reason is saved
-        self.assertEqual(self.job.status, JobStatus.failed)
-        self.assertIn("Out of memory exception", str(self.job.reason))
+        # Assert that the job status is still new
+        self.assertEqual(self.job.status, JobStatus.new)
+        self.assertIsNone(self.job.reason)
 
     @patch("main.services.matching.process_job_runner.ProcessJobRunner.run_job")
     def test_run_next_job_success(self, mock_run_job: MagicMock) -> None:
-        """Method run_next_job should update the Job in the DB if Job runner succeeds in running the Job."""
+        """Method run_next_job should return if Job runner succeeds in running the Job."""
         mock_run_job.return_value = JobResult(0, None)
+        self.matching_service.logger = MagicMock()
 
         self.matching_service.run_next_job()
 
         # Refresh the job from the database to get updated status
         self.job.refresh_from_db()
 
-        # Assert that the job status is succeeded and the reason is None
-        self.assertEqual(self.job.status, JobStatus.succeeded)
+        # Assert that the job status is still new
+        self.assertEqual(self.job.status, JobStatus.new)
         self.assertIsNone(self.job.reason)
+
+        # Failure is not logged
+        self.assertFalse(
+            any(
+                call.args[0].startswith("Unexpected job runner failure")
+                for call in self.matching_service.logger.error.call_args_list
+            )
+        )
+        self.assertTrue(
+            any(
+                call.args[0].startswith("Processed job")
+                for call in self.matching_service.logger.info.call_args_list
+            )
+        )
 
 
 class MatchingServiceConcurrencyTestCase(TransactionTestCase):
@@ -136,6 +164,11 @@ class MatchingServiceConcurrencyTestCase(TransactionTestCase):
 
         # Both jobs should have succeeded
         self.job1.refresh_from_db()
-        self.assertEqual(self.job1.status, JobStatus.succeeded)
+        self.assertEqual(self.job1.status, JobStatus.new)
         self.job2.refresh_from_db()
-        self.assertEqual(self.job2.status, JobStatus.succeeded)
+        self.assertEqual(self.job2.status, JobStatus.new)
+
+        all_info_calls = [str(call.args[0]) for call in mock_logger.info.call_args_list]
+        job_finished_logs = [msg for msg in all_info_calls if "Processed job" in msg]
+
+        self.assertEqual(len(job_finished_logs), 2)

--- a/backend/main/tests/services/matching/test_process_job_runner.py
+++ b/backend/main/tests/services/matching/test_process_job_runner.py
@@ -64,7 +64,7 @@ class ProcessJobRunnerTestCase(TestCase):
         ]
         mock_sel.get_map.side_effect = [True, False]
 
-        job_result = self.process_job_runner.run_job(self.job)
+        job_result = self.process_job_runner.run_job()
 
         # Refresh the job from the database to check for updates
         self.job.refresh_from_db()
@@ -103,7 +103,7 @@ class ProcessJobRunnerTestCase(TestCase):
         ]
         mock_sel.get_map.side_effect = [True, False]
 
-        job_result = self.process_job_runner.run_job(self.job)
+        job_result = self.process_job_runner.run_job()
 
         # Refresh the job from the database to check for updates
         self.job.refresh_from_db()


### PR DESCRIPTION
## Describe your changes
Making Matcher responsible for Job lifecycle (setting status to succeeded/failed) ensures that whenever a job succeeds, it's recorded. It also simplifies reasoning about the job lifecycle since it's confined within a single transaction/process.
