### PR TITLE
Improve MatchGraph.analyze_graph performance for large data sets

### DIFF
--- a/backend/main/services/matching/matcher.py
+++ b/backend/main/services/matching/matcher.py
@@ -6,7 +6,7 @@ from typing import (
     cast,
 )
 
-import duckdb
+import duckdb  # type: ignore[import-untyped]
 import pandas as pd
 from django.db import connection, transaction
 from django.db.backends.utils import CursorWrapper

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,4 +16,4 @@ PyJWT==2.10.1
 requests==2.32.3
 rustworkx==0.15.1
 s3fs==2025.5.1
-splink==4.0.6
+splink==4.0.9


### PR DESCRIPTION
## Describe your changes
This drastically improves the performance of analyzing the match graph when importing data, especially on larger datasets (1+ million records). The old implementation relied on using `.subgraph` to create subgraphs of auto-matched edges when iterating over match groups, and then using `connected_components` on those subgraphs to find auto-match groups. It turns out that `subgraph` is actually quite an expensive operation, though.

Through testing, it's far more performant to do a `connected_components` call twice on the _entire_ graph. Once for the initial match groups, and a second time for the auto-matched groups.

This implementation was tested against a synthetic dataset of 100k records, and seems to produce identical results to the original implementation. The actual performance improvement on my test case of 1.5 million records takes the runtime (on my hardware) from 10-15 minutes to <15 seconds. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reworked matching analysis to process connected components centrally, improving reliability and consistency of automated match grouping and person consolidation.
  * Streamlined auto-match handling to reduce fragmentation and produce clearer group results.

* **Chores**
  * Updated dependency: splink upgraded to 4.0.9 for the latest improvements and fixes.
  * Adjusted typing configuration for third-party library to quiet type warnings (no runtime impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->